### PR TITLE
Branch5

### DIFF
--- a/Labs/ComplexIntegration/residues.tex
+++ b/Labs/ComplexIntegration/residues.tex
@@ -29,7 +29,7 @@ Here we will show another method for visualizing complex functions.
 In Lab \ref{Lab:complex_intro} we presented color plots as a useful method functions in the complex plane. 
 Here we will also show how to use surface plots to visualize the modulus of complex functions.
 
-Now you have to take care when a surface plot is about a singularity, we must account for the fact that the function is not going to be defined at all of the points we use in our graph.
+Now you have to take care when a surface plot is about a singularity.  We must account for the fact that the function is not going to be defined at all of the points we use in our graph.
 We will also have to limit the $z$ axis on the plot to avoid creating a plot that is dominated exclusively by the extremely large and extremely small values of the function.
 Plotting libraries like Mayavi and Matplotlib do allow thresholding of 3D plots via the use of floating point values of \li{nan}, but doing this may result in graphs having jagged edges where they have been cut.
 We can avoid the jagged edges by artificially adding a small lip of constant values to the plot as well.
@@ -113,7 +113,7 @@ Suppose that $z_0$ is a pole of order $1$ of $f$.
 Then
 \[\Res{z=z_0} f(z) = \frac{p(z_0)}{q'(z_0)}\]
 
-A natural consequence of the Laurent series expansion of $f(z)$ and $f'(z)$ at a pole $z_0$ is that, where $d$ is the degree of the pole at $z_0$ is that
+A natural consequence of the Laurent series expansion of $f(z)$ and $f'(z)$ at a pole $z_0$ is that, where $d$ is the degree of the pole at $z_0$,
 \[- \Res{z=z_0} \frac{f'(z)}{f(z)} = d\]
 This is a useful bit of information that may be used to simplify computation of residues or of the Laurent series expansion of a function since it allows us to avoid evaluating a long series of integrals we already know will evaluate to $0$.
 

--- a/Labs/Pseudospectra/Pseudospectra.tex
+++ b/Labs/Pseudospectra/Pseudospectra.tex
@@ -12,13 +12,13 @@ Let $\sigma(A)$ be point spectrum, of a matrix $A$, which can be defined by
 	&=\{\text{points where }(zI-A)^{-1} \text{ is undefined}\}.
 \end{align}
 By convention, if $z$ is an eigenvalue of $A$, then $\|(zI-A)^{-1}\|=\infty$.
-The psuedospectrum of a matrix is a generalization of its point spectrum. The $\epsilon$-psuedospectrum of the matrix $A$ is defined as
+The pseudospectrum of a matrix is a generalization of its point spectrum. The $\epsilon$-pseudospectrum of the matrix $A$ is defined as
 \begin{equation}
 	\sigma_{\epsilon}(A)=\{z \in \mathbb{C}:\|(zI-A)^{-1}\| > \epsilon^{-1}\}.
 \end{equation}
 Note that this definition requires the use of a matrix norm. Any matrix norm can be used, but in this Lab, we will use the norm induced by the 2-norm.\\
 
-In the case of the 2-norm, the psuedospectrum has an equivalent definition:
+In the case of the 2-norm, the pseudospectrum has an equivalent definition:
 \begin{equation}
 	\sigma_{\epsilon}(A)=\{z \in \mathbb{C}: z \in \sigma(A+E) \text{ for some $E$ with } \|E\|<\epsilon\}.
 \end{equation}
@@ -61,7 +61,7 @@ def ps_scatter_plot(A, epsilon=.001, num_pts=20):
     '''
 \end{lstlisting}
 
-To get random matrices of the right norm generate random matrices than divide by the 2-norm and then multiply by epsilon.
+To get random matrices of the right norm generate random matrices then divide by the 2-norm and then multiply by epsilon.
 Have your code also plot the eigenvalues of $A$ in a different color. Test your code on the 120x120 matrix:
 \begin{equation}
 	\begin{pmatrix}
@@ -149,7 +149,7 @@ Note that while this algorithm gives better results than our previous method of 
 \begin{figure}
 \begin{center}
 \includegraphics[width=\textwidth]{ps_contour}
-\caption{Contour plot of the $\epsilon$-psuedospectrum of the matrix given in Problem 1, with $\epsilon=10^{-2},10^{-3},\cdots,10^{-7}$. }
+\caption{Contour plot of the $\epsilon$-pseudospectrum of the matrix given in Problem 1, with $\epsilon=10^{-2},10^{-3},\cdots,10^{-7}$. }
 \label{fig:ps_contour}
 \end{center}
 \end{figure}
@@ -196,7 +196,7 @@ Figure \ref{fig:ps_normal} provides an example of this. The plots show the pseud
 	\end{pmatrix}.
 \end{equation}
 
-Note that these matrices have the same same set of eigenvalues, and that $B$ is normal, while $B'$ is not. The plot of the pseudospectrum of $B$ shows the expected circular regions, but the plot for $B'$ lacks such symmetry. Another example of this can be seen in Figure \ref{fig:ps_scatter}. The pseudospectrum does not expand out from all of the eigenvalues evenly. Most of the region contained in the pseudospectrum lies on the sides of the plot, and not close to the center.\\
+Note that these matrices have the same set of eigenvalues, and that $B$ is normal, while $B'$ is not. The plot of the pseudospectrum of $B$ shows the expected circular regions, but the plot for $B'$ lacks such symmetry. Another example of this can be seen in Figure \ref{fig:ps_scatter}. The pseudospectrum does not expand out from all of the eigenvalues evenly. Most of the region contained in the pseudospectrum lies on the sides of the plot, and not close to the center.\\
 
 Because the pseudospectra of normal matrices behave so consistently, the study of pseudospectra focuses on nonnormal matrices. Pseudospectra can also be used to study infinite-dimensional linear operators, but different methods are required for plotting their pseudospectra.
 

--- a/Python/Profiling/Profiling.tex
+++ b/Python/Profiling/Profiling.tex
@@ -141,7 +141,7 @@ If you must use nested loops, focus your optimization efforts on the innermost l
 \subsection*{Use Existing Functions Instead of Writing Your Own}
 If there is an intuitive operation you would like to perform on an array, chances are that NumPy or another library already has a function that does it.
 Python and NumPy functions have already been optimized, and are usually many times faster than the equivalent you might write.
-We saw an example of this in Lab \ref{} where we compared NumPy array multiplication with our own matrix multiplication implemented in Python.
+We saw an example of this in Lab \ref{lab:NumPyArrays} where we compared NumPy array multiplication with our own matrix multiplication implemented in Python.
 
 \subsection*{Use Generators When Possible}
 When you are iterating through a list, you can often replace the list with a \emph{generator}.
@@ -436,11 +436,11 @@ Cython code can be compiled and imported to IPython with the Cython magic functi
 Load this function with the following command.
 \footnote{In older versions of IPython and Cython, you may need to use the command \li{\%load_ext cythonmagic}.}
 \begin{lstlisting}
->>> \%load_ext Cython
+>>> %load_ext Cython
 \end{lstlisting}
 Now you can define any Cython function in the command line by prefacing it with \li{\%\%cython}.
 \begin{lstlisting}
->>> \%\%cython
+>>> %%cython
 >>> import numpy as np
 >>> from scipy import linalg as la
 >>> def qr():


### PR DESCRIPTION
For lines 439 and 429 the \% was showing up in the yellow code boxes.  Removing the \ made it so that just % was showing up in the code box.