### PR TITLE
raise large file size to 500KB

### DIFF
--- a/travis_pre.py
+++ b/travis_pre.py
@@ -4,8 +4,8 @@ import sys
 import travis_common as tc
 
 
-# 100KB in bytes
-MAX_FILESIZE = 104400
+# 500KB in bytes
+MAX_FILESIZE = 512000
 
 def getOutput(cmd):
     return os.popen(cmd).read()


### PR DESCRIPTION
Files that don't meet this size requirement:
- baloons_resized_noisy.png (AnisotropicDiffusion)
- sinxsiny.png (matplotlib)
- arctan_riemann_surface.pdf (ComplexNumbers)
- poly_color_plot_imag.pdf (ComplexNumbers)
- poly_color_plot_real.pdf (ComplexNumbers)
- LeastSquares.pdf (GMRES)
- ManyMinima.pdf (Scipy.Optimize)