### PR TITLE
Scipy Optimize proofreading

### DIFF
--- a/Labs/Vol2B/scipyoptimize/scipyoptimize.tex
+++ b/Labs/Vol2B/scipyoptimize/scipyoptimize.tex
@@ -161,17 +161,12 @@ For example, if we try using the Nelder-Mead method as previously, with an initi
 
 However, SciPy does have some tools to help us with these problems. 
 Specifically, we can use the \li{opt.basinhopping()} function.
-Conceptually, most of the minimizing algorithms use the derivative of the function to search in a downhill direction for potential minimizers.
-Often they overshoot the minimum and later backtrack. 
-You can think of it as a ball rolling down a hill into a valley.
-At first, the momentum of the ball carries it across the valley floor and partially up the other wall, only to roll back into the valley.
-Slowly the ball loses momentum as it repeatedly overshoots and backtracks. 
-Eventually the ball comes to rest at the bottom of a valley -- hopefully the lowest valley.
-However, if there are many valleys (or local minima), the ball can get stuck in one that's not the lowest.
+
 The \li{opt.basinhopping()} function uses the same minimizing algorithms (in fact, you can tell it whatever minimizing algorithm you can pass to \li{opt.minimize()}).
-However, once it settles on a minimum, it hops to a new point in the domain (depending on how we set the ``hopping" distance) that hopefully lies outside of the valley
+However, once it settles on a minimum, it hops randomly to a new point in the domain (depending on how we set the ``hopping" distance) that hopefully lies outside of the valley
 or basin belonging to the current local minimum.
 It then searches for the minimum from this new starting point, and if it finds a better minimizer, it repeats the hopping process from this new minimizer. 
+Thus, the \li{opt.basinhopping()} function has multiple chances to escape a local basin and find the correct global minimum. 
 
 \emph{Only Scipy Version 0.12+ has \li{opt.basinhopping}. In earlier versions, such as 0.11, you won't find it.}
 

--- a/Labs/Vol2B/scipyoptimize/scipyoptimize.tex
+++ b/Labs/Vol2B/scipyoptimize/scipyoptimize.tex
@@ -276,15 +276,14 @@ Examine the following example from the online documentation.
 The variable \li{popt} now contains the fitted parameters and \li{pcov} gives the covariance of the fit.
 See Figure \ref{opt:curve_fit} for a plot of the data and the fitted curve.
 
-One of the most fundamental phenomena in the physical and engineering sciences is turbulent convection wherein an unstable density gradient induces a fluid to move chaotically (basically, hot air rises).  
+One of the most fundamental phenomena in the physical and engineering sciences is turbulent convection, wherein an unstable density gradient induces a fluid to move chaotically (basically, hot air rises).  
 This problem is so important that experiments and numerical simulations have been pushed to their limits in the past several decades to determine the qualitative nature of the fluid's motion under an extreme forcing (think of boiling a pot of water, but instead at temperatures akin to the interior of the sun).  
-The strength of the forcing (amount of the enforced temperature gradient) is measured by the non-dimensional Rayleigh number.  
-Of paticular interest is to determine how well the chaotic turbulent flow transports the heat from the hot bottom to the cold top, as measured by the Nusselt number.  
-One of the primary goals of experiments, simulations, and analysis is to determine how the Nusselt number depends on the Rayleigh number, i.e. if the bottom of the pot of water is heated more strongly, how much faster does the boiling water transport heat to the top?
+The strength of the forcing (amount of the enforced temperature gradient) is measured by the non-dimensional Rayleigh number $R$.  
+Of paticular interest is to determine how well the chaotic turbulent flow transports the heat from the hot bottom to the cold top, as measured by the Nusselt number $\nu$.  
+One of the primary goals of experiments, simulations, and analysis is to determine how the Nusselt number $\nu$ depends on the Rayleigh number $R$, i.e. if the bottom of the pot of water is heated more strongly, how much faster does the boiling water transport heat to the top?
 
 It is often generically believed that the Nusselt number obeys a power law of the form $\nu = cR^\beta$, where $\beta \le 1/2$.  
-Through some mild assumptions on the temperature, we can construct an eigenvalue problem that we solve numerically for a variety of Rayleigh numbers, to obtain an upper bound on the Nusselt number given by the data prescribed here.  
-Hence, this data should give us some bound on the Nusselt number as $\nu \le cR^\beta$.  Depending on exact physical specifications of the problem, we may even expect $\beta < 1/2$.
+Through some mild assumptions on the temperature, we can construct an eigenvalue problem that we solve numerically for a variety of Rayleigh numbers, thus obtaining an upper bound on the Nusselt number as $\nu \le cR^\beta$.  With our physical specifications of the problem, we may predict $\beta < 1/2$.
 
 \begin{figure}
 \includegraphics[width=\textwidth]{curve_fit.pdf}


### PR DESCRIPTION
See #1140. With @jmorrise's encouragement, slimmed down the intro to the basinhopping problem. (ie. got rid of the metaphor of a rolling ball, which I've thought was rather misleading and confusing).

Also made slight changes to the introduction of the convection problem.