### PR TITLE
Matplotlib Aspect Ratio Instructions

### DIFF
--- a/Labs/Introduction/PlottingIntro/PlottingIntro.tex
+++ b/Labs/Introduction/PlottingIntro/PlottingIntro.tex
@@ -400,7 +400,7 @@ Use \li{np.load()} to load the data, then create a single figure with two subplo
 Because of the large number of data points, use black pixel markers (use \li{"k,"} as the third argument to \li{plt.plot()}).
 Label both axes.
 \\
-(Hint: Use \li{plt.gca().set_aspect("equal")} to equalize the axes on the scatter plot).
+(Hint: Use \li{plt.axis("equal")} to fix the axis ratio on the scatter plot).
 
 \item A histogram of the hours of the day, with one bin per hour.
 Set the limits of the $x$-axis appropriately.

--- a/Labs/Introduction/PlottingIntro/solutions.py
+++ b/Labs/Introduction/PlottingIntro/solutions.py
@@ -107,7 +107,7 @@ def prob5():
     plt.plot(data[:,1], data[:,2], 'k,')
     plt.xlabel("Longitude")
     plt.ylabel("Latitude")
-    plt.gca().set_aspect("equal")
+    plt.axis("equal")
 
     plt.subplot(212)
     plt.hist(data[:,0], bins=24, range=[-.5, 23.5])


### PR DESCRIPTION
In Matplotlib, there are (as far as I know) two easy ways to get the scales on the axes to be the same (ie, a unit on the x axis is the same length as a unit on the y axis):

```python
import numpy as np
from matplotlib import pyplot as plt

x = np.linspace(0, 10, 100)

# Method one: plt.axis()
plt.plot(x, x**2)
plt.axis("equal")
plt.show()

# Method two: plt.gca().set_aspect("equal") (plt.gca() is "get current axis")
plt.plot(x, x**2)
plt.gca().set_aspect("equal")
plt.show()
```
The first method is syntactically easier and looks better when using subplots. However, it may also change the actual limits of the axes to fill the provided space. This is a good option for doing a scatter plot of longitude-latitude coordinates, but bad for the horse plots in the Linear Transformations lab.

The second method grabs the "current axis" (the plot you're currently modifying) and sets the aspect ratio to be equal. This method doesn't change the axis limits, so it's better for the horse.

This PR tweaks the Intro to Plotting lab so it hints at using `plt.axis("equal")` instead of `plt.gca().set_aspect("equal")`. Keep this in mind for Data Visualization (see Issue #1209).