### PR TITLE
Rename a data file in PageRank

### DIFF
--- a/Vol1B/PageRank/PageRank.tex
+++ b/Vol1B/PageRank/PageRank.tex
@@ -35,10 +35,10 @@ An example is illustrated in Figure \ref{fig:network1}.
 \node[draw=none, node distance=2.5cm](0)[right of=1]{0};
 \node[draw=none](dummy)[above right of=0]{};
 \node[draw=none, node distance=.5cm](7)[below
-	of=dummy]{7};
+  of=dummy]{7};
 
 \foreach \x/\y in {3/2, 4/5, 5/6, 1/0, 3/0, 4/0, 5/0} \draw[->,
-	>=stealth'](\x)--(\y);
+  >=stealth'](\x)--(\y);
 \draw[->, >=stealth'](6)--(0);
 \draw[->, >=stealth', shorten >= .1cm](7)edge[bend left=20](0);
 \draw[->, >=stealth', shorten <= .1cm](0)edge[bend left=20](7);
@@ -95,13 +95,13 @@ This means we modify Figure \ref{fig:network1} (where node 2 is a sink) to look 
 \node[draw=none, node distance=2.5cm](0)[right of=1]{0};
 \node[draw=none](dummy)[above right of=0]{};
 \node[draw=none, node distance=.5cm](7)[below
-	of=dummy]{7};
+  of=dummy]{7};
 
 
 \draw[->, color=black!35!](2)--(1);
 \draw[->, color=black!35!, shorten >= .2cm](2)--(0);
 \foreach \x/\y in {2/3, 2/4, 2/5} \draw[->, color=black!35!](\x)
-	edge[bend right](\y);
+  edge[bend right](\y);
 
 \draw[->, shorten <= .1cm, color=black!35!](2)edge[bend right=50](7,-.35);
 \draw[->, shorten <= .1cm](3)edge[bend right=40](6.9,-.25);
@@ -112,7 +112,7 @@ This means we modify Figure \ref{fig:network1} (where node 2 is a sink) to look 
 \draw[->, shorten <= .1cm](0)edge[bend left=20](7);
 
 \foreach \x/\y in {3/2, 4/5, 5/6, 1/0, 3/0, 4/0, 5/0} \draw[->,
-	>=stealth'](\x)--(\y);
+  >=stealth'](\x)--(\y);
 \draw[-> ](6)--(0);
 
 \end{tikzpicture}
@@ -140,7 +140,7 @@ where $\mathbf{p}(t)=(p_1(t), p_2(t), \ldots, p_N(t))^T$,
 $\mathbf{1}$ is a vector of $N$ ones,
 and $K$ is defined by
 \[K_{ij} = \begin{cases} \frac{1}{\abs{\Out(j)}} & \mbox{ if j links to i} \\
-	0 & \mbox{ otherwise.} \end{cases}\]
+  0 & \mbox{ otherwise.} \end{cases}\]
 
 
 \subsection*{Defining Page Rank}
@@ -174,10 +174,10 @@ def to_matrix( filename, n ):
 
     INPUTS:
     filename - Name of a .txt file describing a directed graph. Lines
-    		    describing edges should have the form
-				'<from node>\t<to node>'.
-				The file may also include comments.
-    n		- The number of nodes in the graph described by datafile
+            describing edges should have the form
+        '<from node>\t<to node>'.
+        The file may also include comments.
+    n   - The number of nodes in the graph described by datafile
 
     RETURN:
     Return a NumPy array.
@@ -185,15 +185,15 @@ def to_matrix( filename, n ):
 \end{lstlisting}
 Hints:
 \begin{enumerate}
-\item The file \texttt{datafile.txt} included with this lab describes the matrix in Figure \ref{fig:network1} and has the adjacency matrix \li{A} given above.
+\item The file \texttt{matrix.txt} included with this lab describes the matrix in Figure \ref{fig:network1} and has the adjacency matrix \li{A} given above.
 You may use it to test your function.
 
 \item You can open a file in Python using the \li{with} syntax.
 Then, you can iterate through the lines using a \li{for} loop.
 Here is an example.
 \begin{lstlisting}
-# Open `datafile.txt' for read-only
-with open('./datafile.txt', 'r') as myfile:
+# Open `matrix.txt' for read-only
+with open('./matrix.txt', 'r') as myfile:
     for line in myfile:
         print line
 \end{lstlisting}
@@ -207,7 +207,7 @@ with open('./datafile.txt', 'r') as myfile:
 ['0', '4']
 \end{lstlisting}
 
-\item Rather than testing for lines of \texttt{datafile.txt} that contain comments, put all your string operations in a \li{try} block with an \li{except} block following.
+\item Rather than testing for lines of \texttt{matrix.txt} that contain comments, put all your string operations in a \li{try} block with an \li{except} block following.
 \end{enumerate}
 \end{problem}
 
@@ -418,7 +418,7 @@ There is more than one right way to do this.
 
 The purpose of this section is not to give an introduction to NetworkX, but rather, to introduce you to just enough to be able to analyze the basic properties of a network and apply NetworkX's implementation of PageRank. NetworkX takes advantage of the sparse nature of these networks. Therefore, they are more efficient than the ones we have coded in this lab.
 
-We will first run through the simple steps to initialize the graph defined in Figure \ref{fig:network1}. We will initialize this graph using the edges defined in \li{datafile.txt}. If we create an $n \times 2$ matrix of the edges of this graph, we would get,
+We will first run through the simple steps to initialize the graph defined in Figure \ref{fig:network1}. We will initialize this graph using the edges defined in \li{matrix.txt}. If we create an $n \times 2$ matrix of the edges of this graph, we would get,
 
 \begin{lstlisting}
 >>> edges = array([[ 0,  7],


### PR DESCRIPTION
Names like `datafile.txt` are too generic. I changed it to `matrix.txt`, which is also awfully generic, but it doesn't have the word "data" in it.