### PR TITLE
Change \li to \lif for code in footnote

### DIFF
--- a/PythonEssentials/UnitTesting/UnitTesting.tex
+++ b/PythonEssentials/UnitTesting/UnitTesting.tex
@@ -70,7 +70,7 @@ In fact, the author of a black box test doesn't even need to be the person who e
 
 \section*{PyTest} % ===========================================================
 
-Python's \li{pytest} module\footnote{Pytest is not part of the standard libray, but it is included in Anaconda's Python distribution. Install pytest with \li[basicstyle=\footnotesize\ttfamily]{conda install pytest} if needed. The standard library's \li[basicstyle=\footnotesize\ttfamily]{unittest} module also provides a testing framework, but is less popular and straightforward than PyTest.} provides tools for building tests, running tests, and providing detailed information about the results.
+Python's \li{pytest} module\footnote{Pytest is not part of the standard libray, but it is included in Anaconda's Python distribution. Install pytest with \lif{conda install pytest} if needed. The standard library's \lif{unittest} module also provides a testing framework, but is less popular and straightforward than PyTest.} provides tools for building tests, running tests, and providing detailed information about the results.
 To begin, run \li{pytest} in the current directory.
 Without any test files, the output should be similar to the following.
 


### PR DESCRIPTION
This fixes a problem with the footnote on page 100