### PR TITLE
Add necessary import specs

### DIFF
--- a/PythonEssentials/UnitTesting/UnitTesting.tex
+++ b/PythonEssentials/UnitTesting/UnitTesting.tex
@@ -239,6 +239,7 @@ The corresponding unit tests checks that the function raises the \li{ZeroDivisio
 
 \begin{lstlisting}
 # test_specs.py
+import specs
 import pytest
 
 def test_divide():


### PR DESCRIPTION
The function `test_divide` calls functions from spec.py, so the file needs to be imported 